### PR TITLE
fix: update randombytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "randombytes": "2.0.3"
+    "randombytes": "^2.1.0"
   },
   "devDependencies": {
     "jest": "^26.6.3"


### PR DESCRIPTION
An updated version of `randombytes` is necessary for it to work with webpack 5.